### PR TITLE
Update hashps with cyclesps

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -829,7 +829,6 @@ start:
 	sprintf(req, gbt_req, coinbase_addr);
 	gettimeofday(&tv_start, NULL);
 
-	printf("%s\n", req);
 	val = json_rpc_call(curl, rpc_url, rpc_userpass, req, &err, JSON_RPC_QUIET_404);
 	gettimeofday(&tv_end, NULL);
 	free(req);
@@ -1099,7 +1098,6 @@ static void stratum_gen_work(struct stratum_ctx *sctx, struct work *work)
 		       work->job_id, xnonce2str, swab32(work->data[17]));
 		free(xnonce2str);
 	}
-	applog(LOG_DEBUG, "setting diff to target: %f", sctx->job.diff);
 	diff_to_target(work->target, sctx->job.diff);
 }
 

--- a/util.c
+++ b/util.c
@@ -767,13 +767,9 @@ void diff_to_target(uint32_t *target, double diff)
 	uint64_t m;
 	int k;
 
-	applog(LOG_DEBUG, "miner diff: %f", diff);
-
 	for (k = 7; k > 0 && diff > 1.0; k--)
 		diff /= 4294967296.0;
 	m = 2147450880.0 / diff;
-
-	applog(LOG_DEBUG, "diff: %x; m: %x", diff, m);
 
 	memset(target, 0, 32);
 	target[k] = (uint32_t)m;

--- a/util.c
+++ b/util.c
@@ -13,6 +13,7 @@
 #define _GNU_SOURCE
 #include "cpuminer-config.h"
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -745,7 +746,7 @@ bool fulltest(const uint32_t *hash, const uint32_t *target)
 		char hash_str[65], target_str[65];
 
 		for (i = 0; i < 8; i++) {
-			le32enc(hash_be + i, hash[7 - i]);
+			be32enc(hash_be + i, hash[7 - i]);
 			be32enc(target_be + i, target[7 - i]);
 		}
 		bin2hex(hash_str, (unsigned char *)hash_be, 32);
@@ -766,9 +767,13 @@ void diff_to_target(uint32_t *target, double diff)
 	uint64_t m;
 	int k;
 
+	applog(LOG_DEBUG, "miner diff: %f", diff);
+
 	for (k = 7; k > 0 && diff > 1.0; k--)
 		diff /= 4294967296.0;
-	m = 4294901760.0 / diff;
+	m = 2147450880.0 / diff;
+
+	applog(LOG_DEBUG, "diff: %x; m: %x", diff, m);
 
 	memset(target, 0, 32);
 	target[k] = (uint32_t)m;


### PR DESCRIPTION
Updates:
 - initial difficulty 1 updated to correspond with `7fff8000..` instead `ffff000...`
 - number of found cycle are accumulated instead number of checked hashes
 - `hash/s` changed `cycle/s`
 - quick check performed before full hash check
 - fixed cycle hash debug output 